### PR TITLE
Fix sms viewing after scrum

### DIFF
--- a/src/UE/Application/ISmsDb.hpp
+++ b/src/UE/Application/ISmsDb.hpp
@@ -12,7 +12,7 @@ class ISmsDb {
   virtual ~ISmsDb() = default;
 
   virtual void addReceivedSms(const Sms& sms) = 0;
-  virtual void addSms(const Sms& sms) = 0;
+  virtual void addSentSms(const Sms& sms) = 0;
   virtual std::unique_ptr<Sms> retrieveSms(size_t index) = 0;
   virtual void markAsViewed(size_t index) = 0;
   virtual void markLastSmsSentAsFailed() = 0;

--- a/src/UE/Application/Ports/UserPort.cpp
+++ b/src/UE/Application/Ports/UserPort.cpp
@@ -67,14 +67,24 @@ void UserPort::showSmsList() {
   gui.showNewSms(false);
   IUeGui::IListViewMode& listMode = gui.setListViewMode();
   listMode.clearSelectionList();
+
   for (const auto& sms : smsDb.getSmsMessages()) {
-    std::string header = "from " + common::to_string(sms.first.getFrom()) +
-                         " to " + common::to_string(sms.first.getTo());
+    std::string header{""};
+    if (sms.first.getFrom() == phoneNumber &&
+        sms.first.getTo() == phoneNumber) {
+      header = "From/To: " + common::to_string(sms.first.getTo());
+    } else if (sms.first.getFrom() == phoneNumber) {
+      header = " To : " + common::to_string(sms.first.getTo());
+    } else if (sms.first.getTo() == phoneNumber) {
+      header = "From: " + common::to_string(sms.first.getFrom());
+    }
     if (!sms.first.isReceived()) {
       header = "Fail! " + header;
     }
+
     listMode.addSelectionListItem(header, "");
   }
+
   gui.setAcceptCallback([this, &listMode] { onAcceptCallback(listMode); });
 }
 

--- a/src/UE/Application/Ports/UserPort.cpp
+++ b/src/UE/Application/Ports/UserPort.cpp
@@ -39,7 +39,6 @@ void UserPort::showConnected() {
   }
   menu.addSelectionListItem("Dial", "");
 
-
   gui.setAcceptCallback([this, &menu] { onAcceptCallback(menu); });
 }
 

--- a/src/UE/Application/SmsDb.cpp
+++ b/src/UE/Application/SmsDb.cpp
@@ -5,11 +5,13 @@
 namespace ue {
 
 void SmsDb::addReceivedSms(const Sms& sms) {
-  smsMessages.emplace_back(sms, SmsState::NotViewed);
+  smsMessages.insert(smsMessages.begin(),
+                     std::make_pair(sms, SmsState::NotViewed));
 }
 
 void SmsDb::addSentSms(const Sms& sms) {
-  smsMessages.emplace_back(sms, SmsState::Viewed);
+  smsMessages.insert(smsMessages.begin(),
+                     std::make_pair(sms, SmsState::Viewed));
 }
 
 void ue::SmsDb::markLastSmsSentAsFailed() {

--- a/src/UE/Application/SmsDb.cpp
+++ b/src/UE/Application/SmsDb.cpp
@@ -8,8 +8,8 @@ void SmsDb::addReceivedSms(const Sms& sms) {
   smsMessages.emplace_back(sms, SmsState::NotViewed);
 }
 
-void SmsDb::addSms(const Sms& sms) {
-  smsMessages.emplace_back(sms, SmsState::NotViewed);
+void SmsDb::addSentSms(const Sms& sms) {
+  smsMessages.emplace_back(sms, SmsState::Viewed);
 }
 
 void ue::SmsDb::markLastSmsSentAsFailed() {

--- a/src/UE/Application/SmsDb.hpp
+++ b/src/UE/Application/SmsDb.hpp
@@ -17,7 +17,7 @@ class SmsDb : public ISmsDb {
   void addReceivedSms(const Sms& sms) override;
   const SmsMessages& getSmsMessages() { return smsMessages; }
   std::unique_ptr<Sms> retrieveSms(size_t index) override;
-  void addSms(const Sms& sms) override;
+  void addSentSms(const Sms& sms) override;
   void markAsViewed(size_t index) override;
   void markLastSmsSentAsFailed() override;
   bool isUnreadSms() override;

--- a/src/UE/Application/States/ConnectedState.cpp
+++ b/src/UE/Application/States/ConnectedState.cpp
@@ -44,7 +44,7 @@ void ConnectedState::acceptButton() {
 void ConnectedState::rejectButton() {}
 
 void ConnectedState::handleFailedSmsSend() {
-  context.smsDb.markLastSmsSentAsFailed();
+  context.user.getSmsDb().markLastSmsSentAsFailed();
 }
 
 void ConnectedState::handleSendCallRequest(

--- a/src/UE/Application/States/SendingSmsState.cpp
+++ b/src/UE/Application/States/SendingSmsState.cpp
@@ -12,7 +12,7 @@ void SendingSmsState::acceptButton() {
   common::PhoneNumber toPhoneNumber = iSmsComposeMode.getPhoneNumber();
   Sms sms = Sms{text, context.bts.getOwnPhoneNumber(), toPhoneNumber, true,
                 std::chrono::system_clock::now()};
-  context.smsDb.addSms(sms);
+  context.user.getSmsDb().addSentSms(sms);
   context.bts.sendSms(sms);
   context.setState<ConnectedState>();
 }

--- a/src/UE/Tests/Application/Mocks/ISmsDbMock.hpp
+++ b/src/UE/Tests/Application/Mocks/ISmsDbMock.hpp
@@ -12,7 +12,7 @@ class ISmsDbMock : public ISmsDb {
   ~ISmsDbMock() override = default;
 
   MOCK_METHOD(void, addReceivedSms, (const Sms&), (final));
-  MOCK_METHOD(void, addSms, (const Sms&), (final));
+  MOCK_METHOD(void, addSentSms, (const Sms&), (final));
   MOCK_METHOD(void, markAsViewed, (size_t index), (final));
   MOCK_METHOD(void, markLastSmsSentAsFailed, (), (final));
   MOCK_METHOD(std::unique_ptr<Sms>, retrieveSms, (size_t), (final));

--- a/src/UE/Tests/Application/Mocks/SmsDbMock.hpp
+++ b/src/UE/Tests/Application/Mocks/SmsDbMock.hpp
@@ -12,7 +12,7 @@ class SmsDbMock : public SmsDb {
   ~SmsDbMock() override = default;
 
   MOCK_METHOD(void, addReceivedSms, (const Sms&), (final));
-  MOCK_METHOD(void, addSms, (const Sms&), (final));
+  MOCK_METHOD(void, addSentSms, (const Sms&), (final));
 };
 
 }  // namespace ue


### PR DESCRIPTION
improvment in viewing sms after last scrum meeting:
- unset sms show as "failed"
- logical display order
- better title in sms list (without "to my_number")